### PR TITLE
Rewrite IRQ Handler, etc.

### DIFF
--- a/app/src/event2Test.c
+++ b/app/src/event2Test.c
@@ -54,17 +54,17 @@ void ErIrqHandler(int fd, int flags)
 	if (mydrp == -1)
 	    mydrp = lastdrp - 1;
 	for (drp = mydrp + 1; drp <= lastdrp; drp++) {
-            int idx = drp & (MAX_EVR_DBQ - 1);
-            int databuf_sts = pEq->dbq[idx].status;
+            int idx = drp & (MAX_EVR_DBQ2 - 1);
+            int databuf_sts = pEq->dbq2[idx].status;
 
             if(databuf_sts & (1<<C_EVR_DATABUF_CHECKSUM)) {
                 printf("C%d\n", idx);
             } else {
-                u32 *dd = pEq->dbq[idx].data;
-                printf("D%d: %08x %08x.%08x\n", idx, dd[0], dd[7], dd[8]);
+                u32 *dd = pEq->dbq2[idx].data;
+                printf("D%02d: %08x %08x.%08x\n", idx, dd[0], dd[7], dd[8]);
 #if 0
                 pCard->DBuffSize = (databuf_sts & ((1<<(C_EVR_DATABUF_SIZEHIGH+1))-1));
-                memcpy(pCard->DataBuffer, pEq->dbq[idx].data, pCard->DBuffSize);
+                memcpy(pCard->DataBuffer, pEq->dbq2[idx].data, pCard->DBuffSize);
 #endif
             }
         }

--- a/app/src/event2Test.c
+++ b/app/src/event2Test.c
@@ -7,6 +7,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
+#include <x86intrin.h>
 #include "evrIrqHandler.h"
 #include "erapi.h"
 
@@ -20,18 +21,7 @@ u16 ErEventTab[256];
 int noI = 0;
 long long lasttsc = 0;
 
-#if	defined(__x86_64__)
-#define		read_tsc(tscVal)	     			       \
-do								       \
-{	/*	=A is for 32 bit mode reading 64 bit integer */	       \
-	unsigned long	tscHi, tscLo;      			       \
-	__asm__ volatile("rdtsc" : "=a" (tscLo), "=d" (tscHi) );       \
-	tscVal	=  (long long)( tscHi ) << 32;      		       \
-	tscVal	|= (long long)( tscLo );                               \
-}	while ( 0 );
-#elif	defined(__i386__)
-#define	read_tsc(tscVal)	__asm__ volatile("rdtsc": "=A" (tscVal))
-#endif
+#define	read_tsc(tscVal) (tscVal) = _rdtsc()
 
 double ms_per_tick = 1.0L / 2400148.L;
 

--- a/app/src/event2Test.c
+++ b/app/src/event2Test.c
@@ -17,23 +17,48 @@ int irqCount = 0;
 long long mydrp = -1;
 long long myerp = -1;
 u16 ErEventTab[256];
+int noI = 0;
+long long lasttsc = 0;
+
+#if	defined(__x86_64__)
+#define		read_tsc(tscVal)	     			       \
+do								       \
+{	/*	=A is for 32 bit mode reading 64 bit integer */	       \
+	unsigned long	tscHi, tscLo;      			       \
+	__asm__ volatile("rdtsc" : "=a" (tscLo), "=d" (tscHi) );       \
+	tscVal	=  (long long)( tscHi ) << 32;      		       \
+	tscVal	|= (long long)( tscLo );                               \
+}	while ( 0 );
+#elif	defined(__i386__)
+#define	read_tsc(tscVal)	__asm__ volatile("rdtsc": "=A" (tscVal))
+#endif
+
+double ms_per_tick = 1.0L / 2400148.L;
 
 void ErIrqHandler(int fd, int flags)
 {
     int i;
     irqCount++;
 
-    printf("I%08x\n", flags);
+    if (!noI) {
+        long long tsc;
+        read_tsc(tsc);
+        printf("I %5.3lf %08x\n", (tsc - lasttsc) * ms_per_tick, flags);
+        lasttsc = tsc;
+    }
 
     /* This should always be here 2ms before the fiducial event */
     if(flags & EVR_IRQFLAG_DATABUF) {
-        long long drp = pEq->dwp - 1; /* Read the latest! */
-        if (drp != mydrp) {
+        long long lastdrp = pEq->dwp - 1; /* Read the latest! */
+	long long drp;
+	if (mydrp == -1)
+	    mydrp = lastdrp - 1;
+	for (drp = mydrp + 1; drp <= lastdrp; drp++) {
             int idx = drp & (MAX_EVR_DBQ - 1);
             int databuf_sts = pEq->dbq[idx].status;
 
             if(databuf_sts & (1<<C_EVR_DATABUF_CHECKSUM)) {
-                putchar('C');
+                printf("C%d\n", idx);
             } else {
                 u32 *dd = pEq->dbq[idx].data;
                 printf("D%d: %08x %08x.%08x\n", idx, dd[0], dd[7], dd[8]);
@@ -44,7 +69,7 @@ void ErIrqHandler(int fd, int flags)
             }
         }
         /* TBD - Check if we skipped some? */
-        mydrp = drp;
+        mydrp = lastdrp;
     } else {
         /* We must have skipped one earlier, but caught up? */
     }
@@ -117,9 +142,12 @@ int main(int argc,char *argv[])
     int dbuf = 0;
     int i;
     void *mem;
+    char *dev = getenv("EVRNAME");
 
     memset(ErEventTab, 0, sizeof(ErEventTab));
-    fd = EvrOpen(&mem, "/dev/era4");
+    dev = dev ? dev : "/dev/era4";
+    printf("Opening %s.\n", dev);
+    fd = EvrOpen(&mem, dev);
     pEq = (struct EvrQueues *) mem;
     if (fd < 0) {
         perror("evrTest");
@@ -132,7 +160,15 @@ int main(int argc,char *argv[])
             if (argv[i][0] == '-') {
                 if (argv[i][1] == 'd')
                     dbuf = EVR_IRQFLAG_DATABUF;
-                else {
+                else if (argv[i][1] == 'i')
+                    noI = 1;
+                else if (argv[i][1] == 'h') {
+                    printf("event2Test [ -d ] [ -i ] N1 N2...\n");
+                    printf("    where -d = use data buffers\n");
+                    printf("          -i = don't print IRQ entry\n");
+                    printf("          Nn = event code to enable\n");
+                    exit(0);
+                } else {
                     printf("Unknown argument: %s\n", argv[i]);
                 }
             } else if (argv[i][0] >= '0' && argv[i][0] <= '9') {

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -21,7 +21,7 @@
 # ==========================================================
 MISCUTILS_MODULE_VERSION	= R2.2.4
 DIAG_TIMER_MODULE_VERSION	= R1.9.2.1
-EV2_DRIVER_MODULE_VERSION	= R1.0.2
+EV2_DRIVER_MODULE_VERSION	= R1.0.3
 TIMING_API_MODULE_VERSION	= R0.10
 
 # ==========================================================
@@ -33,10 +33,13 @@ TIMING_API_MODULE_VERSION	= R0.10
 MISCUTILS		= $(EPICS_MODULES)/miscUtils/$(MISCUTILS_MODULE_VERSION)
 DIAG_TIMER		= $(EPICS_MODULES)/diagTimer/$(DIAG_TIMER_MODULE_VERSION)
 EV2_DRIVER		= $(EPICS_MODULES)/ev2_driver/$(EV2_DRIVER_MODULE_VERSION)
-TIMING_API	    = $(EPICS_MODULES)/timingApi/$(TIMING_API_MODULE_VERSION)
+TIMING_API	        = $(EPICS_MODULES)/timingApi/$(TIMING_API_MODULE_VERSION)
 
 # Set EPICS_BASE last so it appears last in the DB, DBD, INCLUDE, and LIB search paths
 EPICS_BASE              = $(EPICS_SITE_TOP)/base/$(BASE_MODULE_VERSION)
+
+#MCB_MODULES = /cds/home/m/mcbrowne/git/modules
+#EV2_DRIVER		= $(MCB_MODULES)/ev2_driver
 
 # Check for undefined EPICS_BASE
 -include $(TOP)/../../EPICS_BASE.check

--- a/evrSupport/src/bsa.c
+++ b/evrSupport/src/bsa.c
@@ -54,6 +54,7 @@
  
 =============================================================================*/
 
+#define USE_TYPED_RSET
 #include <string.h>        /* strcmp */
 #include <stdlib.h>        /* calloc */
 #include <stdio.h>

--- a/evrSupport/src/bsaRecord.c
+++ b/evrSupport/src/bsaRecord.c
@@ -21,6 +21,7 @@
  *                    beam synchronous acquisition.
  */
 
+#define USE_TYPED_RSET
 #include <string.h>
 
 #include "dbDefs.h"

--- a/evrSupport/src/bsacompressRecord.c
+++ b/evrSupport/src/bsacompressRecord.c
@@ -20,6 +20,7 @@
  *      Date:            7-14-89 
  */
 
+#define USE_TYPED_RSET
 #define _ISOC99_SOURCE
 #include <math.h>
 #include <stddef.h>
@@ -69,15 +70,15 @@ rset bsacompressRSET={
 	RSETNUMBER,
 	report,
 	initialize,
-	init_record,
-	process,
+	(long (*)()) init_record,
+	(long (*)()) process,
 	special,
 	get_value,
 	cvt_dbaddr,
 	get_array_info,
 	put_array_info,
 	get_units,
-	get_precision,
+	(long (*)()) get_precision,
 	get_enum_str,
 	get_enum_strs,
 	put_enum_str,

--- a/evrSupport/src/evrEvDesc.c
+++ b/evrSupport/src/evrEvDesc.c
@@ -1,3 +1,4 @@
+#define USE_TYPED_RSET
 #ifdef __rtems__
 #include <rtems.h>            /* required for timex.h      */
 #endif

--- a/evrSupport/src/evrEvInvariantDelay.c
+++ b/evrSupport/src/evrEvInvariantDelay.c
@@ -1,3 +1,4 @@
+#define USE_TYPED_RSET
 #ifdef __rtems__
 #include <rtems.h>            /* required for timex.h      */
 #endif

--- a/evrSupport/src/evrMessage.c
+++ b/evrSupport/src/evrMessage.c
@@ -27,6 +27,7 @@
 
 =============================================================================*/
 
+#define USE_TYPED_RSET
 #include <stddef.h>             /* size_t                      */
 #include <string.h>             /* strcmp                      */
 #include <stdio.h>              /* printf                      */

--- a/evrSupport/src/evrTime.h
+++ b/evrSupport/src/evrTime.h
@@ -61,6 +61,7 @@ extern "C" {
 
 #include    "epicsTime.h"          /* epicsTimeStamp       */
 #include    "registryFunction.h"   /* REGISTRYFUNCTION     */
+#include    "fidmath.h"
   
 /* Masks used to decode pulse ID from the nsec part of the timestamp   */
 #define UPPER_15_BIT_MASK       (0xFFFE0000)    /* (2^32)-1 - (2^17)-1 */
@@ -89,21 +90,6 @@ extern int lastfid;                             /* Keep this for a while to avoi
  ** If the timing module cannot determine the correct fiducial, it returns TIMING_PULSEID_INVALID.  */
 extern epicsUInt64	timingGetFiducialForTimeStamp( epicsTimeStamp  timeStamp );
 
-
-/*
- * A few fiducial helper definitions.
- * FID_ROLL(a, b) is true if we have rolled over from fiducial a to fiducial b.  (That is, a
- * is large, and b is small.)
- * FID_GT(a, b) is true if fiducial a is greater than fiducial b, accounting for rollovers.
- * FID_DIFF(a, b) is the difference between two fiducials, accounting for rollovers.
- */
-#define FID_MAX        0x1ffe0
-#define FID_ROLL_LO    0x00200
-#define FID_ROLL_HI    (FID_MAX-FID_ROLL_LO)
-#define FID_ROLL(a,b)  ((b) < FID_ROLL_LO && (a) > FID_ROLL_HI)
-#define FID_GT(a,b)    (FID_ROLL(b, a) || ((a) > (b) && !FID_ROLL(a, b)))
-#define FID_DIFF(a,b)  ((FID_ROLL(b, a) ? FID_MAX : 0) + (int)(a) - (int)(b) - (FID_ROLL(a, b) ? FID_MAX : 0))
-  
 /* For time ID */
 typedef enum {
   evrTimeCurrent=0, evrTimeNext1=1, evrTimeNext2=2, evrTimeNext3=3, evrTimeActive

--- a/evrSupport/src/longSubRecord.c
+++ b/evrSupport/src/longSubRecord.c
@@ -26,6 +26,7 @@
  */
 
 
+#define USE_TYPED_RSET
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/mrfApp/src/Makefile
+++ b/mrfApp/src/Makefile
@@ -101,6 +101,7 @@ OBJS_IOC_vxWorks 	+= $(drvEvent2_OBJS)
 # Install include files
 #
 INC += mrfCommon.h
+INC += fidmath.h
 # INC += mrfVme64x.h
 
 #INC += drvMrfEr.h

--- a/mrfApp/src/devMrfEr.c
+++ b/mrfApp/src/devMrfEr.c
@@ -60,6 +60,7 @@
 /*  If EVR_DEBUG Flag is Defined, Make All Local Routines Globally Callable                       */
 /**************************************************************************************************/
 
+#define USE_TYPED_RSET
 #ifdef EVR_DEBUG
 #define LOCAL_RTN
 #endif

--- a/mrfApp/src/drvLinuxEvr.c
+++ b/mrfApp/src/drvLinuxEvr.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <byteswap.h>
 #include "erapi.h"
+#include "fidmath.h"
 
 #define DEVNODE_NAME_BASE	"/dev/er"
 #define DEVNODE_MINOR            '4'
@@ -54,22 +55,6 @@
 #define EVR_IRQ_OFF      0x0000         /* Turn off All Interrupts                                */
 #define EVR_IRQ_ALL      0x001f         /* Enable All Interrupts                                  */
 #define EVR_IRQ_TELL     0xffff         /* Return Current Interrupt Enable Mask                   */
-
-
-/*
- * From evrTime.h: A few fiducial helper definitions.
- * FID_ROLL(a, b) is true if we have rolled over from fiducial a to fiducial b.  (That is, a
- * is large, and b is small.)
- * FID_GT(a, b) is true if fiducial a is greater than fiducial b, accounting for rollovers.
- * FID_DIFF(a, b) is the difference between two fiducials, accounting for rollovers.
- */
-#define FID_MAX        0x1ffe0
-#define FID_INVALID    0x1ffff
-#define FID_ROLL_LO    0x00200
-#define FID_ROLL_HI    (FID_MAX-FID_ROLL_LO)
-#define FID_ROLL(a,b)  ((b) < FID_ROLL_LO && (a) > FID_ROLL_HI)
-#define FID_GT(a,b)    (FID_ROLL(b, a) || ((a) > (b) && !FID_ROLL(a, b)))
-#define FID_DIFF(a,b)  ((FID_ROLL(b, a) ? FID_MAX : 0) + (int)(a) - (int)(b) - (FID_ROLL(a, b) ? FID_MAX : 0))
 
 /**************************************************************************************************/
 /*                              Global variables                                                  */

--- a/mrfApp/src/drvLinuxEvr.c
+++ b/mrfApp/src/drvLinuxEvr.c
@@ -230,7 +230,6 @@ void ErIrqHandler(int fd, int flags)
 		 *     TimestampHigh is the seconds field, which at SLAC is used to hold
 		 *     the fiducial count for this event.
 		 */
-		 */
 
 #define SET_NEXT_EFID()				                                             \
 		{				                                             \

--- a/mrfApp/src/drvLinuxEvr.c
+++ b/mrfApp/src/drvLinuxEvr.c
@@ -55,6 +55,22 @@
 #define EVR_IRQ_ALL      0x001f         /* Enable All Interrupts                                  */
 #define EVR_IRQ_TELL     0xffff         /* Return Current Interrupt Enable Mask                   */
 
+
+/*
+ * From evrTime.h: A few fiducial helper definitions.
+ * FID_ROLL(a, b) is true if we have rolled over from fiducial a to fiducial b.  (That is, a
+ * is large, and b is small.)
+ * FID_GT(a, b) is true if fiducial a is greater than fiducial b, accounting for rollovers.
+ * FID_DIFF(a, b) is the difference between two fiducials, accounting for rollovers.
+ */
+#define FID_MAX        0x1ffe0
+#define FID_INVALID    0x1ffff
+#define FID_ROLL_LO    0x00200
+#define FID_ROLL_HI    (FID_MAX-FID_ROLL_LO)
+#define FID_ROLL(a,b)  ((b) < FID_ROLL_LO && (a) > FID_ROLL_HI)
+#define FID_GT(a,b)    (FID_ROLL(b, a) || ((a) > (b) && !FID_ROLL(a, b)))
+#define FID_DIFF(a,b)  ((FID_ROLL(b, a) ? FID_MAX : 0) + (int)(a) - (int)(b) - (FID_ROLL(a, b) ? FID_MAX : 0))
+
 /**************************************************************************************************/
 /*                              Global variables                                                  */
 /*                                                                                                */
@@ -179,7 +195,7 @@ void ErIrqHandler(int fd, int flags)
 {
 	struct ErCardStruct *pCard;
         struct EvrQueues *pEq;
-	int i;
+
 	epicsMutexLock(ErCardListLock);
 	for (pCard = (ErCardStruct *)ellFirst(&ErCardList);
 		pCard != NULL;
@@ -198,68 +214,147 @@ void ErIrqHandler(int fd, int flags)
 
                 irqCount++;
 
-		if(flags & EVR_IRQFLAG_EVENT) {
-                    long long erplimit = pEq->ewp;     /* Pointer to the next! */
-                    long long erp      = pCard->erp;   /* Where we are now. */
-                    if (erp == -1)
-                        erp = erplimit - 1;            /* If just starting, jump to where we are now. */
-                    if (erplimit - erp > MAX_EVR_EVTQ / 2) {
-                        /* Wow, we're far behind! Catch up a bit, but flag an error. */
-                        erp = erplimit - MAX_EVR_EVTQ / 2;
-                        flags |= EVR_IRQFLAG_FIFOFULL;
-                    }
-#if 0
-                    // TODO: How to ensure we callback for event code 1 before other event codes
-                    for( long long ec1Check = erplimit - 1; ec1Check >= erp; ec1Check-- )
-                    {
-                        // TODO: struct FIFOEvent *fe = GetFifoEvent( pEq, erp );
-                        struct FIFOEvent *fe = &pEq->evtq[erp & (MAX_EVR_EVTQ - 1)];
-						if ( fe->EventCode == 1 )
-                        {
-							lastFid = fe->TimestampHigh;
-							break;
-                        }
-                    }
-#endif
-                    for(i=0; erp < erplimit && i < EVR_FIFO_EVENT_LIMIT; erp++) {
-                        struct FIFOEvent *fe = &pEq->evtq[erp & (MAX_EVR_EVTQ - 1)];
-                        if (pCard->ErEventTab[fe->EventCode] & (1 << 15)) {
-                            if (pCard->DevEventFunc != NULL)
-                               (*pCard->DevEventFunc)(pCard, fe->EventCode, fe->TimestampHigh);
-                            i++;
-                        }
-                    }
-                    pCard->erp = erp;
+                long long erp      = pCard->erp;
+		long long drp      = pCard->drp;
+		u32 lastnsec       = pCard->lastnsec;
+		int nextEfid = FID_INVALID;
+		int nextDfid = FID_INVALID;
+
+		/* If just starting or hopelessly behind, jump to where we are now. */
+		if (drp == -1 || pEq->dwp - drp >= 12) {
+		    erp = pEq->ewp - 1;
+		    drp = pEq->dwp - 1;
 		}
 
-                /*
-                 * This should always be here 2ms before the fiducial event.  That said, this means
-                 * that the *next* one comes 0.7ms *after* a fiducial event.  So if we have some
-                 * latency, we're almost always going to have the fiducial interrupt extending over
-                 * into the data buffer time.  So we do the *event* first!
-                 */
-		if(flags & EVR_IRQFLAG_DATABUF) {
-                    long long drp = pEq->dwp - 1; /* Read the latest! */
-                    if (drp != pCard->drp) {
-                        int idx = drp & (MAX_EVR_DBQ - 1);
-                        int databuf_sts = pEq->dbq[idx].status;
+		/*
+		 * OK, the usual sequence of events is:
+		 *     D F+3
+		 *     delay ~2ms
+		 *     E1 F
+		 *     Em F+1
+		 *     En F+1
+		 *     ...
+		 *     delay ~0.7ms
+		 *     D F+4
+		 *
+		 * So we want to figure out what to process next... data buffers or events!
+		 * The important decision comes when we get a fiducial!
+		 */
 
-                        if(databuf_sts & (1<<C_EVR_DATABUF_CHECKSUM)) {
-                            if (pCard->DevErrorFunc != NULL)
-                                (*pCard->DevErrorFunc)(pCard, ERROR_DBUF_CHECKSUM);
-                        } else {
-                            if (pCard->DevDBuffFunc != NULL) {
-                                pCard->DBuffSize = (databuf_sts & ((1<<(C_EVR_DATABUF_SIZEHIGH+1))-1));
-                                memcpy(pCard->DataBuffer, pEq->dbq[idx].data, pCard->DBuffSize);
-                                (*pCard->DevDBuffFunc)(pCard, pCard->DBuffSize, pCard->DataBuffer);
-                            }
-                        }
-                        /* TBD - Check if we skipped some? */
-                        pCard->drp = drp;
-                    } else {
-                        /* We must have skipped one earlier, but caught up? */
-                    }
+#define SET_NEXT_EFID()				                                             \
+		{				                                             \
+		    if (erp < pEq->ewp) {				                     \
+			struct FIFOEvent *fe = &pEq->evtq[erp & (MAX_EVR_EVTQ-1)];           \
+			nextEfid = fe->TimestampHigh + ((fe->EventCode == 1) ? 4 : 3);       \
+			if (nextEfid >= FID_MAX)				             \
+			    nextEfid -= FID_MAX;		                             \
+		    } else						                     \
+			nextEfid = FID_INVALID;				                     \
 		}
+
+#define SET_NEXT_DFID()                                                                      \
+		{							                     \
+		    if (drp < pEq->dwp) {				                     \
+			u32 *dd = pEq->dbq2[drp & (MAX_EVR_DBQ2-1)].data;                    \
+			nextDfid = dd[8] & 0x1ffff;			                     \
+		    } else						                     \
+			nextDfid = FID_INVALID;				                     \
+	        }
+
+#define HANDLE_EVENT()						                             \
+		{                       					 	     \
+		    struct FIFOEvent *fe = &pEq->evtq[erp & (MAX_EVR_EVTQ-1)];               \
+		    int curFid = (fe->TimestampHigh + 4) % FID_MAX;	                     \
+		    if (fe->EventCode == 1 && FID_GT(curFid, nextEfid)) {                    \
+			break;						                     \
+		    };							                     \
+		    erp++;						                     \
+		    if (pCard->ErEventTab[fe->EventCode] & (1 << 15)) {                      \
+			if (fe->EventCode == 1)				                     \
+			    pCard->havefid = 1;                                              \
+			if (pCard->DevEventFunc != NULL)		                     \
+			    (*pCard->DevEventFunc)(pCard, fe->EventCode, fe->TimestampHigh); \
+		    }							                     \
+		}
+
+#define SKIP_DATA()                                                                          \
+		while (drp < pEq->dwp) {					             \
+		    int idx = drp & (MAX_EVR_DBQ2-1);			                     \
+		    int databuf_sts = pEq->dbq2[idx].status;		                     \
+		    u32 *dd = pEq->dbq2[idx].data;				             \
+		    if (databuf_sts & (1<<C_EVR_DATABUF_CHECKSUM)) {                         \
+			if (pCard->DevErrorFunc != NULL)		                     \
+			    (*pCard->DevErrorFunc)(pCard, ERROR_DBUF_CHECKSUM);              \
+			drp++;					                             \
+		    } else if (dd[8] == lastnsec) {				             \
+			drp++;                                                               \
+	            } else						                     \
+			break;						                     \
+		}
+
+#define HANDLE_DATA()                                                                        \
+		{							                     \
+		    int idx = drp & (MAX_EVR_DBQ2-1);			                     \
+		    int databuf_sts = pEq->dbq2[idx].status;		                     \
+		    u32 *dd = pEq->dbq2[idx].data;			                     \
+		    if (pCard->DevDBuffFunc != NULL && pCard->havefid) {		     \
+			pCard->DBuffSize = (databuf_sts &		                     \
+		                            ((1<<(C_EVR_DATABUF_SIZEHIGH+1))-1));	     \
+			memcpy(pCard->DataBuffer, dd, pCard->DBuffSize);                     \
+			(*pCard->DevDBuffFunc)(pCard, pCard->DBuffSize,	pCard->DataBuffer);  \
+	            }								             \
+		    lastnsec = dd[8];					                     \
+		    drp++;						                     \
+		}
+
+		/*
+		 * If we are far behind events, try to catch up, but flag an error!
+		 */
+		if (pEq->ewp - erp > MAX_EVR_EVTQ / 2) {
+		    erp = pEq->ewp - MAX_EVR_EVTQ / 2;
+		    flags |= EVR_IRQFLAG_FIFOFULL;
+		    printf("EVENT FIFO FULL!!\n");
+
+		    /* Now, skip forward to next fiducial event! */
+		    while (erp < pEq->ewp && pEq->evtq[erp & (MAX_EVR_EVTQ-1)].EventCode != 1)
+			erp++;
+		    if (erp < pEq->ewp) /* Skip the fiducial itself! */
+			erp++;
+                }
+
+		SKIP_DATA();   /* Skip if we have duplicates or errors! */
+
+		SET_NEXT_EFID();
+		SET_NEXT_DFID();
+
+		while (erp < pEq->ewp || drp < pEq->dwp) {
+		    /*
+		     * Sigh.  Our macro assumes valid fiducials.  So we need to write the
+		     * comparison carefully.
+		     */
+		    if (nextEfid == FID_INVALID || 
+			(nextDfid != FID_INVALID && FID_GT(nextEfid, nextDfid))) {
+			/* Process a data buffer! */
+			HANDLE_DATA();
+			SKIP_DATA();
+			usleep(1000);
+			SET_NEXT_DFID();
+		    } else {
+			/* Process events until we get to the next fiducial or the end! */
+			while (erp != pEq->ewp) {
+			    HANDLE_EVENT();
+			}
+			SET_NEXT_EFID();
+		    }
+		    if (nextEfid == FID_INVALID)
+			SET_NEXT_EFID();
+		    if (nextDfid == FID_INVALID)
+			SET_NEXT_DFID();
+		}
+
+		pCard->lastnsec = lastnsec;
+		pCard->erp = erp;
+		pCard->drp = drp;
 
 		if(flags & EVR_IRQFLAG_PULSE) {
 			if(pCard->DevEventFunc != NULL)
@@ -433,6 +528,8 @@ static int ErConfigure (
 	memset(pCard, 0, sizeof(struct ErCardStruct));
         pCard->drp = -1;
         pCard->erp = -1;
+	pCard->lastnsec = 0xffffffff;
+	pCard->havefid = 0;
 	pCard->Cardno = Card;
 	pCard->CardLock = epicsMutexCreate();
 	if (pCard->CardLock == 0) {

--- a/mrfApp/src/drvLinuxEvr.c
+++ b/mrfApp/src/drvLinuxEvr.c
@@ -221,7 +221,7 @@ void ErIrqHandler(int fd, int flags)
 		 * So we want to figure out what to process next... data buffers or events!
 		 * The important decision comes when we get a fiducial!
 		 *
-		 * If dd is a pointer to a databufffer, then:
+		 * If dd is a pointer to a databuffer, then:
 		 *     dd[7] is the seconds field of the timestamp.
 		 *     dd[8] is the nanosecond field of the timestamp, the low 17-bits
 		 *     of which are the fiducial count.  

--- a/mrfApp/src/drvLinuxEvr.c
+++ b/mrfApp/src/drvLinuxEvr.c
@@ -211,14 +211,12 @@ void ErIrqHandler(int fd, int flags)
 
 		/*
 		 * OK, the usual sequence of events is:
-		 *     D F+3
-		 *     delay ~2ms
-		 *     E1 F
-		 *     Em F+1
-		 *     En F+1
-		 *     ...
-		 *     delay ~0.7ms
-		 *     D F+4
+		 *     Data buffer for fiducial F+3
+		 *     ~2ms delay
+		 *     Event code 1 with timestamp F
+		 *     Other events with timestamp F+1
+		 *     ~0.7ms delay
+		 *     Data buffer for fiducial F+4
 		 *
 		 * So we want to figure out what to process next... data buffers or events!
 		 * The important decision comes when we get a fiducial!

--- a/mrfApp/src/drvLinuxEvr.c
+++ b/mrfApp/src/drvLinuxEvr.c
@@ -245,9 +245,8 @@ void ErIrqHandler(int fd, int flags)
 		{				                                             \
 		    if (erp < pEq->ewp) {				                     \
 			struct FIFOEvent *fe = &pEq->evtq[erp & (MAX_EVR_EVTQ-1)];           \
-			nextEfid = fe->TimestampHigh + ((fe->EventCode == 1) ? 4 : 3);       \
-			if (nextEfid >= FID_MAX)				             \
-			    nextEfid -= FID_MAX;		                             \
+			nextEfid = (fe->TimestampHigh +			                     \
+				    ((fe->EventCode == 1) ? 4 : 3)) % FID_MAX;               \
 		    } else						                     \
 			nextEfid = FID_INVALID;				                     \
 		}
@@ -265,7 +264,7 @@ void ErIrqHandler(int fd, int flags)
 		{                       					 	     \
 		    struct FIFOEvent *fe = &pEq->evtq[erp & (MAX_EVR_EVTQ-1)];               \
 		    int curFid = (fe->TimestampHigh + 4) % FID_MAX;	                     \
-		    if (fe->EventCode == 1 && FID_GT(curFid, nextEfid)) {                    \
+		    if (fe->EventCode == 1 && curFid != nextEfid) {                          \
 			break;						                     \
 		    };							                     \
 		    erp++;						                     \

--- a/mrfApp/src/drvLinuxEvr.c
+++ b/mrfApp/src/drvLinuxEvr.c
@@ -220,6 +220,16 @@ void ErIrqHandler(int fd, int flags)
 		 *
 		 * So we want to figure out what to process next... data buffers or events!
 		 * The important decision comes when we get a fiducial!
+		 *
+		 * If dd is a pointer to a databufffer, then:
+		 *     dd[7] is the seconds field of the timestamp.
+		 *     dd[8] is the nanosecond field of the timestamp, the low 17-bits
+		 *     of which are the fiducial count.  
+		 *
+		 * If fe is a pointer to a FIFOEvent, then:
+		 *     TimestampHigh is the seconds field, which at SLAC is used to hold
+		 *     the fiducial count for this event.
+		 */
 		 */
 
 #define SET_NEXT_EFID()				                                             \

--- a/mrfApp/src/drvLinuxEvr.c
+++ b/mrfApp/src/drvLinuxEvr.c
@@ -175,7 +175,6 @@ epicsUInt16 ErEnableIrq_nolock (ErCardStruct *pCard, epicsUInt16 Mask)
 |*   it has to figure out why and who generated an interrupt
 |*
 \**************************************************************************************************/
-int irqCount = 0;
 void ErIrqHandler(int fd, int flags)
 {
 	struct ErCardStruct *pCard;
@@ -196,8 +195,6 @@ void ErIrqHandler(int fd, int flags)
                  */
 
 		pEq = pCard->pEq;
-
-                irqCount++;
 
                 long long erp      = pCard->erp;
 		long long drp      = pCard->drp;

--- a/mrfApp/src/drvLinuxEvr.c
+++ b/mrfApp/src/drvLinuxEvr.c
@@ -167,7 +167,8 @@ epicsUInt16 ErEnableIrq_nolock (ErCardStruct *pCard, epicsUInt16 Mask)
 |*
 |*-------------------------------------------------------------------------------------------------
 |* INPUT PARAMETERS:
-|*      pCard     = (ErCardStruct *) Pointer to the Event Receiver card structure.
+|*      fd     = (int) Open fd pointing to the EVR.
+|*      flags  = (int) A mask of interrupt conditions.
 |*
 |*-------------------------------------------------------------------------------------------------
 |* NOTES:

--- a/mrfApp/src/drvMrfEr.h
+++ b/mrfApp/src/drvMrfEr.h
@@ -351,7 +351,9 @@ struct ErCardStruct {
     char            FormFactor;              /* "VME_EVR" or "PMC_EVR" */
     char            EventCodeDesc[EVR_NUM_EVENTS][MAX_STRING_SIZE+1];   /* Event code description */
     long long       drp;                     /* Last data buffer read pointer */
+    epicsUInt32     lastnsec;                /* Last message nsec value */
     long long       erp;                     /* Next event read pointer */
+    int             havefid;                 /* Have we started receiving fiducials yet? */
     epicsUInt32     FPGAVersion;             /* The board version register */
 };/*ErCardStruct*/
 

--- a/mrfApp/src/erRecord.c
+++ b/mrfApp/src/erRecord.c
@@ -55,6 +55,7 @@ DEVELOPMENT CENTER AT ARGONNE NATIONAL LABORATORY (708-252-2000).
  *      Date                    06/28/01
  */
 
+#define USE_TYPED_RSET
 #include        <epicsStdio.h>  
 #include        <dbDefs.h>
 #include        <epicsPrint.h>
@@ -100,8 +101,8 @@ rset erRSET={
 	RSETNUMBER,
 	report,
 	initialize,
-	ErInitRec,
-	ErProc,
+	(long(*)())ErInitRec,
+	(long(*)())ErProc,
 	ErSpecial,
 	get_value,
 	cvt_dbaddr,

--- a/mrfApp/src/ereventRecord.c
+++ b/mrfApp/src/ereventRecord.c
@@ -13,6 +13,7 @@
  *      Date:           8/27/93
  */
 
+#define USE_TYPED_RSET
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -63,8 +64,8 @@ rset ereventRSET={
 	RSETNUMBER,
 	report,
 	initialize,
-	ErEventInitRec,
-	ErEventProc,
+	(long (*)())ErEventInitRec,
+	(long (*)())ErEventProc,
 	special,
 	get_value,
 	cvt_dbaddr,

--- a/mrfApp/src/fidmath.h
+++ b/mrfApp/src/fidmath.h
@@ -1,0 +1,17 @@
+#ifndef __FIDMATH_H_
+#define __FIDMATH_H_
+/*
+ * A few fiducial helper definitions.
+ * FID_ROLL(a, b) is true if we have rolled over from fiducial a to fiducial b.  (That is, a
+ * is large, and b is small.)
+ * FID_GT(a, b) is true if fiducial a is greater than fiducial b, accounting for rollovers.
+ * FID_DIFF(a, b) is the difference between two fiducials, accounting for rollovers.
+ */
+#define FID_MAX        0x1ffe0
+#define FID_INVALID    0x1ffff
+#define FID_ROLL_LO    0x00200
+#define FID_ROLL_HI    (FID_MAX-FID_ROLL_LO)
+#define FID_ROLL(a,b)  ((b) < FID_ROLL_LO && (a) > FID_ROLL_HI)
+#define FID_GT(a,b)    (FID_ROLL(b, a) || ((a) > (b) && !FID_ROLL(a, b)))
+#define FID_DIFF(a,b)  ((FID_ROLL(b, a) ? FID_MAX : 0) + (int)(a) - (int)(b) - (FID_ROLL(a, b) ? FID_MAX : 0))
+#endif


### PR DESCRIPTION
Several changes: most important is the rewrite of the IRQ handler to strictly alternate fiducial events and data buffers.  Other changes include:
- Use new, deeper data buffer queue.
- Remove threads running evrTask and evrRecord and replace signalling these with a direct call to the body.  (These only allowed concurrency where there shouldn't be any anyway.)
- USE_TYPED_RSET everywhere.
- Add a bit more functionality to event2Test.

Presentation: https://docs.google.com/presentation/d/14jurFn0-EBeC4892JlaSdCnCdfvAoJt-spkHOFs33eU/edit?usp=sharing