### PR TITLE
Add ability to use old ev2_driver and improve invalid pattern debugging

### DIFF
--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -21,7 +21,7 @@
 # ==========================================================
 MISCUTILS_MODULE_VERSION	= R2.2.4
 DIAG_TIMER_MODULE_VERSION	= R1.9.2.1
-EV2_DRIVER_MODULE_VERSION	= R1.0.3
+EV2_DRIVER_MODULE_VERSION	= R1.0.5
 TIMING_API_MODULE_VERSION	= R0.10
 
 # ==========================================================

--- a/evrSupport/src/evrPattern.c
+++ b/evrSupport/src/evrPattern.c
@@ -200,10 +200,13 @@ int evrPattern(int fidMsgTimedOut, epicsUInt32 *mpsModifier_p)
     } else {
       pattern_ps->time = prevTime;
     }
-    evrTimePutPulseID(&pattern_ps->time, PULSEID_INVALID);
     if ( ErDebug >= 5 ) {
-        printf("Recvd invalid evr pattern.\n");fflush(stdout);
+        printf("Recvd invalid evr pattern: %d.%09d (%08x.%08x)\n",
+	       pattern_ps->time.secPastEpoch, pattern_ps->time.nsec,
+	       pattern_ps->time.secPastEpoch, pattern_ps->time.nsec);
+	fflush(stdout);
     }
+    evrTimePutPulseID(&pattern_ps->time, PULSEID_INVALID);
     if (epicsTimeDiffInSeconds(&currentTime, mod720time_ps) > MODULO720_SECS)
       pattern_ps->modifier_a[MOD1_IDX] |= MODULO720_MASK;
   } else {

--- a/mrfApp/src/erapi.c
+++ b/mrfApp/src/erapi.c
@@ -37,6 +37,7 @@ extern void EvrIrqHandlerThreadCreate(void (**handler) (int, int), int);
 */
 
 #define DEBUG_PRINTF printf
+int evr_new_dbq = 1; /* A hidden global variable to allow using the "old" driver DBQ. */
 
 int EvrOpen(void **pEq, char *device_name)
 {
@@ -54,7 +55,7 @@ int EvrOpen(void **pEq, char *device_name)
   else
   {
       /* Memory map Event Receiver registers */
-      *pEq = (void *) mmap(0, EVR_SH_MEM_WINDOW, PROT_READ, MAP_SHARED, fd, 0);
+      *pEq = (void *) mmap(0, evr_new_dbq ? EVR_SH_MEM_WINDOW : EVR_SH_MEM_WINDOW_OLD, PROT_READ, MAP_SHARED, fd, 0);
 #ifdef DEBUG
       DEBUG_PRINTF("EvrOpen: mmap returned %p, errno %d\n", *pEq,
                    errno);

--- a/mrfApp/src/erapi.h
+++ b/mrfApp/src/erapi.h
@@ -21,3 +21,4 @@ int EvrSetPulseParams(int fd, int pulse, u32 presc, u32 delay, u32 width,
 void EvrDumpPulses(int fd, int pulses);
 void EvrIrqAssignHandler(int fd, void (*handler)(int, int));
 int EvrGetTimestampCounter(int fd);
+extern int evr_new_dbq;


### PR DESCRIPTION
Some drivers have yet to be changed, so it is useful to be able to run the old ev2_driver.  Also, print more information when a pattern is found to be invalid so we could potentially debug it.
